### PR TITLE
fix for wget options

### DIFF
--- a/zsh-comma-assistant.zsh
+++ b/zsh-comma-assistant.zsh
@@ -178,7 +178,7 @@ function refresh-index() {
     then
         local filename="index-$(uname -m)-$(uname | tr A-Z a-z)"
         mkdir -p $COMMA_INDEX_PATH
-        wget -q --show-progress -N https://github.com/Mic92/nix-index-database/releases/latest/download/$filename -O "$COMMA_INDEX_PATH/files"
+        wget -q --progress=bar --force-progress -N https://github.com/nix-community/nix-index-database/releases/latest/download/$filename -O "$COMMA_INDEX_PATH/files"
         echo "Downloaded latest nix-index cache."
     fi
 


### PR DESCRIPTION
Small error observed : `refresh-index` does rely on `wget`'s `--show-progress` option, which, according to `wget` itself... Does not exist. So here is a fix to that problem that retains the loading bar purpose.

I also used the opportunity to handle the deletion of Mic92's `nix-index-database` into, which became `nix-community/nix-index-database`.
